### PR TITLE
Fix Target is not instantiable while building

### DIFF
--- a/src/FaviconExtractorServiceProvider.php
+++ b/src/FaviconExtractorServiceProvider.php
@@ -18,11 +18,6 @@ class FaviconExtractorServiceProvider extends ServiceProvider
             __DIR__.'/../config/favicon-extractor.php' => config_path('favicon-extractor.php')
         ], 'config');
 
-        $this->mergeConfigFrom(__DIR__.'/../config/favicon-extractor.php', 'favicon-extractor');
-    }
-
-    public function register()
-    {
         $this->app->bind(
             FaviconFactoryInterface::class,
             FaviconFactory::class
@@ -44,5 +39,10 @@ class FaviconExtractorServiceProvider extends ServiceProvider
         );
 
         $this->app->alias(FaviconExtractorInterface::class, 'favicon.extractor');
+    }
+
+    public function register()
+    {
+        $this->mergeConfigFrom(__DIR__.'/../config/favicon-extractor.php', 'favicon-extractor');
     }
 }


### PR DESCRIPTION
Fixes #2 

The problem here was: 
register will be called before boot. So the default configuration variables are not available at this point. (If you do not publish the configuration)