### PR TITLE
Add GitHub provider

### DIFF
--- a/src/Provider/GitHubProvider.php
+++ b/src/Provider/GitHubProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StefanBauer\LaravelFaviconExtractor\Provider;
+
+use GrahamCampbell\GuzzleFactory\GuzzleFactory;
+
+class GitHubProvider implements ProviderInterface
+{
+    public function fetchFromUrl(string $url): string
+    {
+        $client = GuzzleFactory::make();
+        $response = $client->get($this->getUrl($url));
+
+        return $response->getBody()->getContents();
+    }
+
+    private function getUrl(string $url): string
+    {
+        $domain = preg_replace('/https?:\/\/(www\.)?([a-z\-\.]+)\/?.*/i', '$2', $url);
+
+        return 'https://favicons.githubusercontent.com/'.urlencode($domain);
+    }
+}


### PR DESCRIPTION
This adds a GitHub provider to fetch favicons from, which provides higher quality than the Google provider.