### PR TITLE
Larger character set for domain names

### DIFF
--- a/src/Provider/GitHubProvider.php
+++ b/src/Provider/GitHubProvider.php
@@ -18,7 +18,7 @@ class GitHubProvider implements ProviderInterface
 
     private function getUrl(string $url): string
     {
-        $domain = preg_replace('/https?:\/\/(www\.)?([a-z\-\.]+)\/?.*/i', '$2', $url);
+        $domain = preg_replace('/https?:\/\/(www\.)?([\w\-\.]+)\/?.*/i', '$2', $url);
 
         return 'https://favicons.githubusercontent.com/'.urlencode($domain);
     }


### PR DESCRIPTION
Domain names can include much more characters than just `a-z`: `A-Z`, `0-9`, and `_`.